### PR TITLE
feat: add wallpaper generation

### DIFF
--- a/BeatPrints/poster.py
+++ b/BeatPrints/poster.py
@@ -91,7 +91,8 @@ class Poster:
         accent: bool = False,
         theme: ThemesSelector.Options = "Light",
         pcover: Optional[str] = None,
-    ) -> None:
+        return_image: bool = False,
+    ) -> Optional[Image.Image]:
         """
         Generates a poster for a track, which includes lyrics.
 
@@ -101,6 +102,10 @@ class Poster:
             accent (bool, optional): Adds an accent at the bottom of the poster. Defaults to False.
             theme (ThemesSelector.Options, optional): Specifies the theme to use. Must be one of "Light", "Dark", "Catppuccin", "Gruvbox", "Nord", "RosePine", or "Everforest".  Defaults to "Light".
             pcover (Optional[str]): Path to a custom cover image. Defaults to None.
+            return_image (bool, optional): If True, returns the PIL Image object instead of saving. Defaults to False.
+
+        Returns:
+            Optional[Image.Image]: The PIL Image object of the poster if return_image is True, otherwise None.
         """
 
         # Check if the theme is valid or not
@@ -148,13 +153,16 @@ class Poster:
                 anchor="lt",
             )
 
-            # Save the generated poster with a unique filename
-            name = filename(metadata.name, metadata.artist)
-            poster.save(os.path.join(self.save_to, name))
-
-            print(
-                f"✨ Poster for {metadata.name} by {metadata.artist} saved to {self.save_to}"
-            )
+            if return_image:
+                return poster
+            else:
+                # Save the generated poster with a unique filename
+                name = filename(metadata.name, metadata.artist)
+                poster.save(os.path.join(self.save_to, name))
+                print(
+                    f"✨ Poster for {metadata.name} by {metadata.artist} saved to {self.save_to}"
+                )
+                return None
 
     def album(
         self,
@@ -163,7 +171,8 @@ class Poster:
         accent: bool = False,
         theme: ThemesSelector.Options = "Light",
         pcover: Optional[str] = None,
-    ) -> None:
+        return_image: bool = False,
+    ) -> Optional[Image.Image]:
         """
         Generates a poster for an album, which includes track listing.
 
@@ -173,6 +182,10 @@ class Poster:
             accent (bool, optional): Add an accent at the bottom of the poster. Defaults to False.
             theme (ThemesSelector.Options, optional): Specifies the theme to use. Must be one of "Light", "Dark", "Catppuccin", "Gruvbox", "Nord", "RosePine", or "Everforest". Defaults to "Light".
             pcover (Optional[str]): Path to a custom cover image. Defaults to None.
+            return_image (bool, optional): If True, returns the PIL Image object instead of saving. Defaults to False.
+
+        Returns:
+            Optional[Image.Image]: The PIL Image object of the poster if return_image is True, otherwise None.
         """
 
         # Check if the theme mentioned is valid or not
@@ -223,9 +236,13 @@ class Poster:
                 )
                 x += column_width + s.SPACING  # Adjust x for next column
 
-            # Save the generated album poster with a unique filename
-            name = filename(metadata.name, metadata.artist)
-            poster.save(os.path.join(self.save_to, name))
-            print(
-                f"✨ Album poster for {metadata.name} by {metadata.artist} saved to {self.save_to}"
-            )
+            if return_image:
+                return poster
+            else:
+                # Save the generated album poster with a unique filename
+                name = filename(metadata.name, metadata.artist)
+                poster.save(os.path.join(self.save_to, name))
+                print(
+                    f"✨ Album poster for {metadata.name} by {metadata.artist} saved to {self.save_to}"
+                )
+                return None

--- a/BeatPrints/wallpaper.py
+++ b/BeatPrints/wallpaper.py
@@ -1,0 +1,82 @@
+from PIL import Image, ImageDraw, ImageFilter
+
+def draw_drop_shadow(base_image, offset=(10, 10), shadow_color=(0, 0, 0, 128), blur_radius=10):
+    """Draws a drop shadow behind the given image."""
+    shadow = Image.new('RGBA', base_image.size, (0, 0, 0, 0))
+    shadow_draw = ImageDraw.Draw(shadow)
+    shadow_draw.rectangle((0, 0, base_image.width, base_image.height), fill=shadow_color)
+
+    blurred_shadow = shadow.filter(ImageFilter.GaussianBlur(radius=blur_radius))
+
+    shadow_offset = Image.new('RGBA', (base_image.width + abs(offset[0]) * 2, base_image.height + abs(offset[1]) * 2), (0, 0, 0, 0))
+    shadow_offset.paste(blurred_shadow, (abs(offset[0]), abs(offset[1])))
+
+    #Can probably be dropped
+    final_shadow = Image.new('RGBA', shadow_offset.size, (0, 0, 0, 0))
+    final_shadow.paste(shadow_offset, (0, 0))
+
+    return final_shadow
+
+def generate_wallpaper(resolution, image_paths, bg_color):
+    width_res, height_res = resolution
+    num_images = len(image_paths)
+
+    if not 1 <= num_images <= 10:
+        raise ValueError("Number of images must be between 1 and 10.")
+    # Math... Basically take the Wallpaper Width/Height, calculate what the appropriate size of the posters should be
+    # Horizontal gaps between images are set to be 1/16 the size of the images
+    # Gaps between the images and the edges of the wallpaper are set to be at least double the size of the inner gaps
+    # At least one side has to give. The vertical or the horizontal edge gaps
+    # The vertical_gap was chosen arbitrairly as the baseline for comparison
+
+    if num_images > 0:
+        inner_gap_horizontal_ver = width_res / (3 + (17 * num_images))
+        vertical_gap_horizontal_ver = 2 * inner_gap_horizontal_ver
+        vertical_gap_vertical_ver = height_res/(2 + (8*26/19))
+
+        if vertical_gap_horizontal_ver < vertical_gap_vertical_ver:
+            inner_gap = inner_gap_horizontal_ver
+            image_width = inner_gap * 16
+            vertical_gap = vertical_gap_horizontal_ver
+            image_height = (29/19) * image_width
+
+        else:
+            vertical_gap = vertical_gap_vertical_ver
+            inner_gap = vertical_gap / 2
+            image_height = vertical_gap * 26 * 8 / 19
+            image_width = image_height * 19 / 29
+
+    wallpaper = Image.new('RGB', resolution, bg_color)
+    shadow_offset = (int(inner_gap / 8), int(inner_gap / 8))
+    shadow_color = (0, 0, 0, 128)
+    blur_radius = int(inner_gap / 8)
+
+    if num_images > 0:
+        total_images_width = num_images * image_width
+        total_inner_gaps_width = (num_images - 1) * inner_gap
+        horizontal_available_space = width_res - total_images_width - total_inner_gaps_width
+        horizontal_outer_gap = horizontal_available_space / 2
+        vertical_available_space = height_res - image_height
+        vertical_outer_gap = vertical_available_space / 2
+
+        y_position = vertical_outer_gap
+        x_position = horizontal_outer_gap
+
+        for path in image_paths:
+            try:
+                img = Image.open(path).convert("RGBA")
+                resized_img = img.resize((int(image_width), int(image_height)))
+
+                # Draw drop shadow
+                shadow = draw_drop_shadow(resized_img, offset=shadow_offset, shadow_color=shadow_color, blur_radius=blur_radius)
+                wallpaper.paste(shadow, (int(x_position) + shadow_offset[0], int(y_position) + shadow_offset[1]), shadow)
+
+                # Paste the actual image
+                wallpaper.paste(resized_img, (int(x_position), int(y_position)), resized_img)
+
+                x_position += image_width + inner_gap
+            except FileNotFoundError:
+                print(f"Error: Image not found at {path}")
+                # Handle error as needed
+
+    return wallpaper


### PR DESCRIPTION
Hello! First off I want to say thank your for creating such a sick utility! The example image with the three posters made me really wish there was a way to generate wallpapers like that, thus the impetus for this PR.
Understand if you're not interested in merging the changes, as it might seem like it goes beyond the scope of the project, but I thought I would put together this PR in case you are interested in the functionality!

Changes:
poster.py: Added image return to pass the generated posters into the wallpaper.py
wallpaper.py: Calculates the correct poster size to embed in the given wallpaper dimensions. Also adds a drop shadow to each poster
cli/prompt.py: Adds prompting hopefully in line with the spirit of the original program, takes in 1-10 posters to create a wallpaper from. Takes in Wallpaper dimensions, and BG color. Guides users through repeated poster creations

Currently there are a few things that need to be improved, but I'd like to gauge the interest in incorporating this into the main branch before I spend further time developing this. Attached are some wallpapers generated as example.

![phoneWallpaper](https://github.com/user-attachments/assets/f0ff8bc8-1011-451a-9561-f73e63a9473f)
![landscapeWallpaper](https://github.com/user-attachments/assets/03b85a37-7515-4b71-a5a9-eb04c7fdf9a6)


Once again, thanks for making this great little program!!