### PR TITLE
fix(cli): gracefully handle empty search results to prevent crash

### DIFF
--- a/cli/exutils.py
+++ b/cli/exutils.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 from rich import box
 from rich.table import Table
@@ -37,7 +36,7 @@ def clear() -> None:
     Clears the terminal screen.
     """
 
-    subprocess.call("cls" if os.name == "nt" else "clear")
+    os.system("cls" if os.name == "nt" else "clear")
     print(BEATPRINTS_ASCII)
 
 

--- a/cli/prompt.py
+++ b/cli/prompt.py
@@ -29,9 +29,15 @@ def select_track(limit: int):
             qmark="🎺",
         ).unsafe_ask()
 
-        result = [
-            dz.get_track(track["id"]) for track in dz.search(query, "track", limit)
-        ]
+        try:
+            result = [
+                dz.get_track(track["id"]) for track in dz.search(query, "track", limit)
+            ]
+        except errors.NoMatchingTrackFound:
+            exutils.clear()
+            print(f"😦 • No track was found matching [bold cyan]'{query}'[/bold cyan]")
+            print("╰─ Please try searching with a different term!\n")
+            continue
 
         # Clear the screen
         exutils.clear()
@@ -90,10 +96,16 @@ def select_album(limit: int):
             qmark="💿️",
         ).unsafe_ask()
 
-        result = [
-            dz.get_album(album["id"], shuffle)
-            for album in dz.search(query, "album", limit)
-        ]
+        try:
+            result = [
+                dz.get_album(album["id"], shuffle)
+                for album in dz.search(query, "album", limit)
+            ]
+        except errors.NoMatchingAlbumFound:
+            exutils.clear()
+            print(f"😦 • No album was found matching [bold cyan]'{query}'[/bold cyan]")
+            print("╰─ Please try searching with a different term!\n")
+            continue
 
         # Clear the screen
         exutils.clear()


### PR DESCRIPTION
Handle empty Deezer API search results gracefully instead of crashing in CLI
Before:
<img width="961" height="1028" alt="Screenshot_2026-06-16_18-46-26" src="https://github.com/user-attachments/assets/28270343-5e3a-430a-9b6d-9022eac796f3" />
After:
<img width="961" height="1028" alt="Screenshot_2026-06-16_18-48-11" src="https://github.com/user-attachments/assets/c4793a4c-3c55-423e-ba42-64efb9a6cbea" />